### PR TITLE
do not format URLs in code tags

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import '@logseq/libs';
 
 const DEFAULT_REGEX = {
     wrappedInCommand: /(\{\{(video)\s*(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\s*\}\})/gi,
+    wrappedInCodeTags: /((`|```).*(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,}).*(`|```))/gi,
     htmlTitleTag: /<title(\s[^>]+)*>([^<]*)<\/title>/,
     line: /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi,
     imageExtension: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i,
@@ -76,6 +77,15 @@ function isWrappedInCommand(text, url) {
     return wrappedLinks.some(command => command.includes(url));
 }
 
+function isWrappedInCodeTags(text, url) {
+    const wrappedLinks = text.match(DEFAULT_REGEX.wrappedInCodeTags);
+    if (!wrappedLinks) {
+        return false;
+    }
+
+    return wrappedLinks.some(command => command.includes(url));
+}
+
 async function getFormatSettings() {
     const { preferredFormat } = await logseq.App.getUserConfigs();
     if (!preferredFormat) {
@@ -110,7 +120,7 @@ async function parseBlockForLink(uuid: string) {
     for (const url of urls) {
         const urlIndex = text.indexOf(url, offset);
 
-        if (isAlreadyFormatted(text, url, urlIndex, formatSettings.formatBeginning) || isImage(url) || isWrappedInCommand(text, url)) {
+        if (isAlreadyFormatted(text, url, urlIndex, formatSettings.formatBeginning) || isImage(url) || isWrappedInCommand(text, url) || isWrappedInCodeTags(text, url)) {
             continue;
         }
 


### PR DESCRIPTION
The plugin should not touch content of code tags (backtick or triple backtick).

Probably more exceptions like this should be added, but that was what was bothering me today and it was easy to add based on the isWrappedInCommand() function.